### PR TITLE
psutil.NUM_CPUS is Depricated

### DIFF
--- a/ttop/core.py
+++ b/ttop/core.py
@@ -52,7 +52,7 @@ class Bytes(int):
 
 class CPU(object):
 
-    NUM_CPUS = psutil.NUM_CPUS
+    NUM_CPUS = psutil.cpu_count()
 
     def __init__(self, user=0, system=0, idle=0):
         self.update(user, system, idle)


### PR DESCRIPTION
NUM_CPUS is removed in favour of cpu_count().
All other features appear to work intact.

May break when used with older versions of psutil
